### PR TITLE
Add env argument to compile_write function call 

### DIFF
--- a/lib/sassc_rack.rb
+++ b/lib/sassc_rack.rb
@@ -35,7 +35,7 @@ class SasscRack
 
       if File.exist? scssfile
         if @options[:write_file]
-          compile_write(scssfile, writepath)
+          compile_write(env, scssfile, writepath)
         else
           compile_serve(env, scssfile)
         end


### PR DESCRIPTION
I was getting an error when I set write file option to true. Problem was that the function compile_write was called with 2 arguments, but it expects 3 arguments. 

I've added the env argument to the call as first argument. 
